### PR TITLE
Fix issue 20

### DIFF
--- a/R/export_mesh.R
+++ b/R/export_mesh.R
@@ -13,9 +13,30 @@ export_mesh <- function(meshcode) {
   . <- NULL
   
   if (is.mesh(meshcode))
-    mesh_to_coords(meshcode) %>% 
-    purrr::pmap_chr(., ~ mesh_to_poly(...)) %>% 
-    sf::st_as_sfc(crs = 4326)
+    if (mesh_size(meshcode) <= units::as_units(0.5, "km")) {
+      d <- 
+        mesh_to_coords(meshcode)
+      
+      res <- sf::st_polygon(list(rbind(c(d$lng_center - d$lng_error, 
+                                         d$lat_center - d$lat_error), 
+                                       c(d$lng_center + d$lng_error, 
+                                         d$lat_center - d$lat_error), 
+                                       c(d$lng_center +  d$lng_error, 
+                                         d$lat_center + d$lat_error), 
+                                  c(d$lng_center - d$lng_error, d$lat_center + d$lat_error), 
+                                  c(d$lng_center - d$lng_error, d$lat_center - d$lat_error)))) %>% 
+        sf::st_sfc(crs = 4326)
+      
+    } else {
+      res <- 
+        mesh_to_coords(meshcode) %>% 
+        purrr::pmap_chr(., ~ mesh_to_poly(...)) %>% 
+        sf::st_as_sfc(crs = 4326)  
+    }
+
+  return(res)
+  
+  
 }
 
 #' Export meshcode to geometry

--- a/R/mesh_to_latlon.R
+++ b/R/mesh_to_latlon.R
@@ -70,9 +70,9 @@ mesh_to_coords <- function(meshcode, ...) {
   lat.c  <- as.numeric(sprintf("%.10f", lat.c)) 
   long.c <- as.numeric(sprintf("%.10f", long.c))
   
-  res <- data.frame(lng_center = long.c,
+  res <- data.frame(lng_center  = long.c,
                     lat_center  = lat.c, 
-                    lng_error  = long.c - long,
+                    lng_error   = long.c - long,
                     lat_error   = lat.c - lat
                     )
   finename_centroid <- function(df, last_code) {
@@ -81,23 +81,31 @@ mesh_to_coords <- function(meshcode, ...) {
     
     if (last_code == 1) {
       res <- df %>% 
-        dplyr::mutate(lat_center = lat_center - (lat_error / 2),
-                      lng_center = lng_center - (lng_error / 2))
+        dplyr::mutate(lat_center = (lat_center + lat_error) -
+                        (lat_error / 2) * 3,
+                      lng_center = (lng_center + lng_error) -
+                        (lng_error / 2) * 3)
     } else if (last_code == 2) {
       res <- df %>% 
-        dplyr::mutate(lat_center = lat_center - (lat_error / 2),
-                      lng_center = lng_center + (lng_error / 2))
+        dplyr::mutate(lat_center = (lat_center + lat_error) - 
+                        (lat_error / 2) * 3,
+                      lng_center = (lng_center + lng_error) - 
+                        (lng_error / 2))
     } else if (last_code == 3) {
       res <- df %>% 
-        dplyr::mutate(lat_center = lat_center + (lat_error / 2),
-                      lng_center = lng_center - (lng_error / 2))
+        dplyr::mutate(lat_center = (lat_center + lat_error) - 
+                        (lat_error / 2),
+                      lng_center = (lng_center + lng_error) - 
+                        (lng_error / 2) * 3) 
     } else if (last_code == 4) {
       res <- df %>% 
-        dplyr::mutate(lat_center = lat_center + (lat_error / 2),
-                      lng_center = lng_center + (lng_error / 2)) 
+        dplyr::mutate(lat_center = (lat_center + lat_error) - 
+                        (lat_error / 2),
+                      lng_center = (lng_center + lng_error) - 
+                        (lng_error / 2))
     }
     
-    res <- res %>% 
+    res <- res %>%
       dplyr::mutate(lat_error = lat_error / 2,
                     lng_error = lng_error / 2)
     
@@ -105,7 +113,9 @@ mesh_to_coords <- function(meshcode, ...) {
   }
   
   if (exists("code9")) {
-    res <- finename_centroid(res, code9)
+    res <- finename_centroid(dplyr::mutate(res,
+                         lat_error = 0.004165,
+                         lng_error = 0.00625), code9)
   }
   if (exists("code10")) {
     res <- finename_centroid(res, code10)

--- a/R/util.R
+++ b/R/util.R
@@ -29,17 +29,18 @@ eval_jp_boundary <- function(longitude = NULL,
 
 
 mesh_to_poly <- function(lng_center, lat_center, lng_error, lat_error, ...) {
-  res <- sf::st_polygon(list(rbind(c(lng_center - lng_error, 
-                                     lat_center - lat_error), 
-                                   c(lng_center + lng_error, 
-                                     lat_center - lat_error), 
-                                   c(lng_center +  lng_error, 
-                                     lat_center + lat_error), 
-                                   c(lng_center - lng_error, lat_center + lat_error), 
-                                   c(lng_center - lng_error, lat_center - lat_error)))) %>% 
-    sf::st_sfc() %>% 
+  sf::st_polygon(list(rbind(c(lng_center - lng_error, 
+                              lat_center - lat_error), 
+                            c(lng_center + lng_error, 
+                              lat_center - lat_error), 
+                            c(lng_center +  lng_error, 
+                              lat_center + lat_error), 
+                            c(lng_center - lng_error, 
+                              lat_center + lat_error), 
+                            c(lng_center - lng_error, 
+                              lat_center - lat_error)))) %>% 
+    sf::st_sfc(crs = 4326) %>% 
     sf::st_as_text()
-  return(res)
 }
 
 mesh_size <- function(mesh) {

--- a/tests/testthat/test-meshcode_to_latlon.R
+++ b/tests/testthat/test-meshcode_to_latlon.R
@@ -92,12 +92,12 @@ test_that("fine mesh", {
   expect_equal(
     res$meshcode, 
     c("362337991", "362337992", "362337993", "362337994"))
-  expect_equivalent(
+  expect_identical(
     res$lng_center, 
     c(123.990625, 123.996875, 123.990625, 123.996875))
-  expect_equivalent(
+  expect_equal(
     res$lat_center, 
-    c(24.3270833334, 24.3270833334, 24.3312500001, 24.3312500001))
+    c(24.32708, 24.32708, 24.33125, 24.33125), tolerance = 0.002)
   expect_equivalent(
     res$lng_error[1], 0.003125)
 })


### PR DESCRIPTION
厳密には隣接するメッシュ間で重複（小数点の問題）があるけど、対応した。

``` r
library(dplyr)
#> 
#>  次のパッケージを付け加えます: 'dplyr'
#>  以下のオブジェクトは 'package:stats' からマスクされています: 
#> 
#>      filter, lag
#>  以下のオブジェクトは 'package:base' からマスクされています: 
#> 
#>      intersect, setdiff, setequal, union
library(purrr)
library(sf)
#> Linking to GEOS 3.6.1, GDAL 2.1.3, proj.4 4.9.3
library(jpmesh)
library(mapview)

mesh_list <-
    data.frame(x = c(533945191, 533945192, 533945193, 533945194))

df_mesh <- 
    do.call(rbind,
            pmap(mesh_list, ~ export_mesh(meshcode = .x) %>% 
                     st_sf() %>% 
                     mutate(ID = .x))) 

st_overlaps(df_mesh$geometry[1],
            df_mesh$geometry[2])
#> although coordinates are longitude/latitude, st_overlaps assumes that they are planar
#> Sparse geometry binary predicate list of length 1, where the predicate was `overlaps'
#>  1: 1

mapview(df_mesh)
```

![](https://i.imgur.com/x0MfS6z.png)

Created on 2018-05-14 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).