### PR TITLE
メモ化による処理の高速化

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ Depends:
     R (>= 3.1)
 Imports: 
     leaflet (>= 1.1.0),
+    memoise (>= 1.1.0),
     miniUI (>= 0.1.1),
     purrr (>= 0.2.4),
     rlang (>= 0.1.4),

--- a/R/administration_mesh.R
+++ b/R/administration_mesh.R
@@ -33,10 +33,14 @@ administration_mesh <- function(code, to_mesh_size) {
     rlang::inform("The city and the prefecture including it was givend.\nWill return prefecture's meshes.") # nolint
   res_meshes <-
     purrr::map(checked_code,
-               ~ subset(df_city_mesh,
-                        grepl(paste0("^(", .x, ")"),
-                              city_code)) %>%
-                 purrr::pluck("meshcode")) %>%
+               memoise::memoise(
+                 function(.x) {
+                   subset(df_city_mesh,
+                          grepl(paste0("^(", .x, ")"),
+                                city_code)) %>%
+                     purrr::pluck("meshcode")
+                 }
+               )) %>%
     purrr::flatten_chr() %>%
     unique()
   if (to_mesh_size == units::as_units(80, "km")) {

--- a/R/export_mesh.R
+++ b/R/export_mesh.R
@@ -7,17 +7,19 @@
 #' @examples
 #' export_mesh("6441427712")
 #' @export
-export_mesh <- function(meshcode) {
-  if (is_meshcode(meshcode) == FALSE) {
-    meshcode <-
-      meshcode(meshcode)
-  }
-  size <- 
-    mesh_size(meshcode)
-  mesh_to_coords(meshcode) %>% 
-    purrr::pmap_chr(mesh_to_poly) %>% 
-    sf::st_as_sfc(crs = 4326)
-}
+export_mesh <- 
+  memoise::memoise(
+    function(meshcode) {
+      if (is_meshcode(meshcode) == FALSE) {
+        meshcode <-
+          meshcode(meshcode)
+      }
+      size <- 
+        mesh_size(meshcode)
+      mesh_to_coords(meshcode) %>% 
+        purrr::pmap_chr(mesh_to_poly) %>% 
+        sf::st_as_sfc(crs = 4326)
+    })
 
 #' @title Export meshcode to geometry
 #' @description Convert and export meshcode area to `sf`.
@@ -42,7 +44,7 @@ export_meshes <- function(meshcode) {
     purrr::map_chr(vctrs::field(df_meshes$meshcode, "mesh_code"),
                    ~ export_mesh(meshcode = .x) %>%
                      sf::st_as_text()) %>%
-                sf::st_as_sfc()
+    sf::st_as_sfc()
   df_meshes %>% 
     sf::st_sf(crs = 4326) %>% 
     tibble::new_tibble(class = "sf", nrow = nrow(df_meshes))

--- a/R/util.R
+++ b/R/util.R
@@ -122,53 +122,55 @@ meshcode_set_80km <-
 #' meshcode_set(mesh_size = 80, .raw = FALSE)
 #' @return character or [meshcode][meshcode]
 #' @export
-meshcode_set <- function(mesh_size = c(80, 10, 1), .raw = TRUE) {
-  if (mesh_size == 80) {
-    meshcode_80km <- 
-      as.character(meshcode_80km_num)
-  } else {
-    meshcode_10km <- 
-      as.character(meshcode_80km_num) %>% 
-      purrr::map(
-        ~ paste0(.x,
-                 sprintf("%02s",
-                         sort(paste0(rep(seq.int(0, 7), each = 8), seq.int(0, 7))))
-        )) %>% 
-      purrr::flatten_chr()
-  }
-  if (mesh_size == 1) {
-    meshcode_1km <- 
-      meshcode_10km %>% 
-      purrr::map(
-        ~ paste0(.x,
-                 sprintf("%02d", seq.int(0, 99))
-        )) %>% 
-      purrr::flatten_chr()
-  }
-  if (.raw == TRUE) {
+meshcode_set <- memoise::memoise(
+  function(mesh_size = c(80, 10, 1), .raw = TRUE) {
     if (mesh_size == 80) {
-      meshcode_80km
-    } else if (mesh_size == 10) {
-      meshcode_10km
-    } else if (mesh_size == 1) {
-      meshcode_1km
+      meshcode_80km <- 
+        as.character(meshcode_80km_num)
+    } else {
+      meshcode_10km <- 
+        as.character(meshcode_80km_num) %>% 
+        purrr::map(
+          ~ paste0(.x,
+                   sprintf("%02s",
+                           sort(paste0(rep(seq.int(0, 7), each = 8), seq.int(0, 7))))
+          )) %>% 
+        purrr::flatten_chr()
     }
-  } else {
-    if (mesh_size == 80) {
-      meshcode_set_80km
-    } else if (mesh_size <= 10) {
-      meshcode_set_10km <- 
-        meshcode_set_80km %>% 
-        fine_separate()
-      if (mesh_size == 10) {
-        meshcode_set_10km
+    if (mesh_size == 1) {
+      meshcode_1km <- 
+        meshcode_10km %>% 
+        purrr::map(
+          ~ paste0(.x,
+                   sprintf("%02d", seq.int(0, 99))
+          )) %>% 
+        purrr::flatten_chr()
+    }
+    if (.raw == TRUE) {
+      if (mesh_size == 80) {
+        meshcode_80km
+      } else if (mesh_size == 10) {
+        meshcode_10km
       } else if (mesh_size == 1) {
-        meshcode_set_10km %>% 
+        meshcode_1km
+      }
+    } else {
+      if (mesh_size == 80) {
+        meshcode_set_80km
+      } else if (mesh_size <= 10) {
+        meshcode_set_10km <- 
+          meshcode_set_80km %>% 
           fine_separate()
+        if (mesh_size == 10) {
+          meshcode_set_10km
+        } else if (mesh_size == 1) {
+          meshcode_set_10km %>% 
+            fine_separate()
+        }
       }
     }
   }
-}
+)
 
 #' @title Cutoff mesh of outside the area
 #' @inheritParams mesh_to_coords


### PR DESCRIPTION
## Summary

memoiseパッケージを利用。メッシュコードの変換処理はキャッシュを効かせて高速化する。市町村コードの抽出もキャッシュ。

### 対象の関数

- `administration_mesh()`
- `meshcode_set()`
- `export_mesh()` (`export_meshes()`)

### 比較

<details>

<summary>メモ化前</summary>


```r
library(jpmesh)
tictoc::tic()
administration_mesh(code = "35201", to_mesh_size = 1)
tictoc::toc()
#> 6.894 sec elapsed

tictoc::tic()
m <- 
  meshcode_set(10, .raw = FALSE)
tictoc::toc()
#> 7.608 sec elapsed

tictoc::tic()
export_meshes(m)
tictoc::toc()
#> 94.976 sec elapsed
```
</details>

<summary>メモ化後</summary>

```r
pkgload::load_all()
tictoc::tic()
administration_mesh(code = "35201", to_mesh_size = 1)
tictoc::toc()
#> 1.382 sec elapsed

tictoc::tic()
m <- 
  meshcode_set(10, .raw = FALSE)
tictoc::toc()
#> 0.012 sec elapsed

tictoc::tic()
export_meshes(m)
tictoc::toc()
#> 8.695 sec elapsed
```


## Related issues

なし